### PR TITLE
fix: broken csv table

### DIFF
--- a/docs/source/user-guide/master.rst
+++ b/docs/source/user-guide/master.rst
@@ -33,7 +33,7 @@ ChubaoFS 使用 **JSON** 作为配置文件的格式.
    "clusterName", "字符串", "集群名字", "是"
    "exporterPort", "整型", "The prometheus exporter port", "否"
    "consulAddr", "字符串", "consul注册地址，供prometheus exporter使用", "否"
-   "metaNodeReservedMem","字符串","如果metanode的内存小于这个值，metanode被置为只读状态“
+   "metaNodeReservedMem","字符串","如果metanode的内存小于这个值，metanode被置为只读状态"
 
 
 


### PR DESCRIPTION
Fix broken csv table due to the invalid charactor at the end.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>